### PR TITLE
Tables in Word can have differing column widths

### DIFF
--- a/lib/docxtable.js
+++ b/lib/docxtable.js
@@ -99,7 +99,7 @@ module.exports = {
   _tblGrid: function(opts) {
     return {
       "w:gridCol": {
-        "@w:w": opts.tableColWidth || "0"
+        "@w:w": opts.tableColWidth || "1"
       }
     };
   },


### PR DESCRIPTION
The cellColWidth option that is copied to the w:w on a w:tcW only works if the w:gridCol is a non-zero value. It is now possible to set table columns to different widths by using the cellColWidth on the columns for the first row, rather than having to set a constant column with in the table options.
